### PR TITLE
fix: set minimum PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "readme": "README.md",
     "license": "MIT",
     "require": {
-        "friendsofphp/php-cs-fixer": "^3.64"
+        "friendsofphp/php-cs-fixer": "^3.64",
+        "php": ">=8.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.43"


### PR DESCRIPTION
As the `static` return type was added in [PHP 8.0](https://wiki.php.net/rfc/static_return_type), projects with lower versions end up in "Parse error:  syntax error, unexpected 'static' (T_STATIC)".