### PR TITLE
feat: add `blank_line_before_statement` rule

### DIFF
--- a/src/CsFixerConfig.php
+++ b/src/CsFixerConfig.php
@@ -30,6 +30,28 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
         'array_syntax' => [
             'syntax' => 'short',
         ],
+        'blank_line_before_statement' => [
+            'statements' => [
+                'break',
+                'case',
+                'continue',
+                'declare',
+                'default',
+                'exit',
+                'goto',
+                'include',
+                'include_once',
+                'phpdoc',
+                'require',
+                'require_once',
+                'return',
+                'switch',
+                'throw',
+                'try',
+                'yield',
+                'yield_from',
+            ],
+        ],
         'cast_spaces' => [
             'space' => 'none',
         ],


### PR DESCRIPTION
This adds `blank_line_before_statement` rule, initially with config from `@PhpCsFixer` config.

Subject to discuss. Please feel free to add notes/opinions.

see: https://cs.symfony.com/doc/rules/whitespace/blank_line_before_statement.html#rule-sets