### PR TITLE
feat: add HeaderCommentFixer for managing header comments in mono rep…

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,12 @@ declare(strict_types=1);
 $config = FULLHAUS\CodingStandards\CsFixerConfig::create();
 
 // Enable header comment
-$config->enableHeaderComment(`
-▄▄   ▄▄  ▄▄▄▄▄      ▄▄▄  ▄▄▄▄   ▄▄▄▄▄
-██▄█▄██  ██▄▄      ██ ██ ██ ██  ██▄▄ 
-██▀ ▀██  ██▄▄▄     ██▀██ ██▀█▄  ██▄▄▄+
-
-██▀▀▀▀  ██  ██  ██      ██      █   █  ▄▀▀▀▄  █   █  ▄▀▀▀▄
-██▄▄▄   ██  ██  ██      ██      █▄▄▄█  █▄▄▄█  █   █  ▀▄▄▄ 
-██      ██  ██  ██      ██      █   █  █   █  █   █  ▄   █
-▀▀       ▀▀▀▀   ▀▀▀▀▀▀  ▀▀▀▀▀▀  ▀   ▀  ▀   ▀   ▀▀▀    ▀▀▀ 
-`);
+$config->enableHeaderComment(
+    "This file is part of the MyProject package.\n\n" .
+    "(c) 2024-2025 FULLHAUS GmbH\n\n" .
+    "For the full copyright and license information, please view\n" .
+    "the LICENSE file that was distributed with this source code."
+);
 
 $config->getFinder()->in(__DIR__ . '/src');
 
@@ -124,6 +120,7 @@ return $config;
 - ✅ Enable/disable per project
 - ✅ Control header placement and spacing
 - ✅ Automatic header management (add/update/remove)
+- ✅ Available variables: `{package_name}`, `{year}`
 
 **Monorepo example with automatic detection:**
 ```php

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ Follow these steps to integrate the FULLHAUS PHP-CS-Fixer into your project:
 
 1. Add the repository to the `repositories` field in your `composer.json`:
     ```json
-    "repositories": {
-        "fullhaus/php-cs-fixer": {
-            "type": "vcs",
-            "url": "git@github.com:FULLHAUS-GmbH/php-cs-fixer.git"
+    {
+        "repositories": {
+            "fullhaus/php-cs-fixer": {
+                "type": "vcs",
+                "url": "git@github.com:FULLHAUS-GmbH/php-cs-fixer.git"
+            }
         }
     }
     ```
@@ -39,12 +41,14 @@ Follow these steps to integrate the FULLHAUS PHP-CS-Fixer into your project:
 
 4. Add the following snippet to your root `composer.json`:
    ```json
-   "scripts": {
-      "fix:php": [
-         "@fix:php:cs"
-      ],
-      "fix:php:cs": "php-cs-fixer fix --config .php-cs-fixer.php"
-   },
+    {   
+       "scripts": {
+          "fix:php": [
+             "@fix:php:cs"
+          ],
+          "fix:php:cs": "php-cs-fixer fix --config .php-cs-fixer.php"
+       }
+    }
    ```
 
    > ATTENTION: Beware of copy🍝! There might be an existing `scripts` section in your composer.json already. In this case copy the cs-fixer scripts **only**, if not in there, yet. Anyways, IDE will complain about duplicate associative keys.
@@ -81,6 +85,55 @@ This package uses GitHub Actions to automatically run tests on every push and pu
 - Checks code style compliance
 
 See [.github/workflows/tests.yml](.github/workflows/tests.yml) for the complete workflow configuration.
+
+## Features
+
+### Header Comment Fixer for Mono Repos
+
+This package includes a custom fixer for managing header comments in mono repo projects. Each package or project can have its own header comment that will be automatically added to PHP files.
+
+**Quick example:**
+```php
+<?php
+
+declare(strict_types=1);
+
+$config = FULLHAUS\CodingStandards\CsFixerConfig::create();
+
+// Enable header comment
+$config->enableHeaderComment(`
+▄▄   ▄▄  ▄▄▄▄▄      ▄▄▄  ▄▄▄▄   ▄▄▄▄▄
+██▄█▄██  ██▄▄      ██ ██ ██ ██  ██▄▄ 
+██▀ ▀██  ██▄▄▄     ██▀██ ██▀█▄  ██▄▄▄+
+
+██▀▀▀▀  ██  ██  ██      ██      █   █  ▄▀▀▀▄  █   █  ▄▀▀▀▄
+██▄▄▄   ██  ██  ██      ██      █▄▄▄█  █▄▄▄█  █   █  ▀▄▄▄ 
+██      ██  ██  ██      ██      █   █  █   █  █   █  ▄   █
+▀▀       ▀▀▀▀   ▀▀▀▀▀▀  ▀▀▀▀▀▀  ▀   ▀  ▀   ▀   ▀▀▀    ▀▀▀ 
+`);
+
+$config->getFinder()->in(__DIR__ . '/src');
+
+return $config;
+```
+
+**Key features:**
+- ✅ **🆕 Automatic package detection from composer.json**
+- ✅ **🆕 One configuration for entire monorepo**
+- ✅ Configure different headers per package in a mono repo
+- ✅ Enable/disable per project
+- ✅ Control header placement and spacing
+- ✅ Automatic header management (add/update/remove)
+
+**Monorepo example with automatic detection:**
+```php
+$config->setHeaderComment([
+    'enabled' => true,
+    'packages_path' => [__DIR__ . '/packages'],
+    'header_template' => 'This file is part of {package_name}.',
+]);
+// Each package gets its own header based on composer.json name!
+```
 
 ## License
 

--- a/src/CsFixerConfig.php
+++ b/src/CsFixerConfig.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FULLHAUS\CodingStandards;
 
 use FULLHAUS\CodingStandards\Fixer\ArraySpacingFixer;
+use FULLHAUS\CodingStandards\Fixer\HeaderCommentFixer;
 use PhpCsFixer\Config;
 use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
@@ -250,7 +251,10 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
             ->registerCustomFixers([ new ArraySpacingFixer() ])
             ->setRules(array_merge(static::$fullhausRules, [
                 'FULLHAUS/array_spacing' => true,
-            ]));
+            ]))
+            ->registerCustomFixers([
+                new HeaderCommentFixer(),
+            ]);
         $static->getFinder()
             ->exclude(
                 [
@@ -280,5 +284,51 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
         $this->setRules($rules);
 
         return $this;
+    }
+
+    /**
+     * Configure the header comment for mono repo projects.
+     *
+     * @param array<string, mixed> $config Configuration options for the header comment:
+     *                                     - enabled: bool (default: true)
+     *                                     - header: string (the header text)
+     *                                     - location: 'after_open'|'after_declare_strict' (default: 'after_declare_strict')
+     *                                     - separate: 'both'|'top'|'bottom'|'none' (default: 'both')
+     *                                     - comment_type: 'comment'|'PHPDoc' (default: 'comment')
+     */
+    public function setHeaderComment(array $config): static
+    {
+        $rules = $this->getRules();
+        $rules['FULLHAUS/header_comment'] = $config;
+        $this->setRules($rules);
+
+        return $this;
+    }
+
+    /**
+     * Enable the header comment fixer with a simple header text.
+     *
+     * @param string $header The header text (will be wrapped in comment block automatically)
+     * @param string $location Where to place the header (default: 'after_declare_strict')
+     */
+    public function enableHeaderComment(string $header, string $location = 'after_declare_strict'): static
+    {
+        return $this->setHeaderComment([
+            'enabled' => true,
+            'header' => $header,
+            'location' => $location,
+            'separate' => 'both',
+            'comment_type' => 'comment',
+        ]);
+    }
+
+    /**
+     * Disable the header comment fixer.
+     */
+    public function disableHeaderComment(): static
+    {
+        return $this->setHeaderComment([
+            'enabled' => false,
+        ]);
     }
 }

--- a/src/CsFixerConfig.php
+++ b/src/CsFixerConfig.php
@@ -315,7 +315,7 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
      * @param string|array<string> $location Where to place the header (default: 'after_declare_strict')
      *                                       Can be a string or array. When using array, last matching position wins.
      */
-    public function enableHeaderComment(string $header, string|array $location = 'after_declare_strict'): static
+    public function enableHeaderComment(string $header, array|string $location = 'after_declare_strict'): static
     {
         return $this->setHeaderComment([
             'enabled' => true,
@@ -326,7 +326,7 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
         ]);
     }
 
-    public function enableHeaderTemplateComment(string $headerTemplate, array $packagesPath = [], string|array $location = 'after_declare_strict'): static
+    public function enableHeaderTemplateComment(string $headerTemplate, array $packagesPath = [], array|string $location = 'after_declare_strict'): static
     {
         return $this->setHeaderComment([
             'enabled' => true,

--- a/src/CsFixerConfig.php
+++ b/src/CsFixerConfig.php
@@ -292,7 +292,10 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
      * @param array<string, mixed> $config Configuration options for the header comment:
      *                                     - enabled: bool (default: true)
      *                                     - header: string (the header text)
-     *                                     - location: 'after_open'|'after_declare_strict' (default: 'after_declare_strict')
+     *                                     - location: string|array<string> (default: 'after_declare_strict')
+     *                                       Can be 'after_open', 'after_declare_strict', or an array of both.
+     *                                       When using array, the last matching position wins.
+     *                                       Example: ['after_open', 'after_declare_strict'] will use after_declare_strict if present
      *                                     - separate: 'both'|'top'|'bottom'|'none' (default: 'both')
      *                                     - comment_type: 'comment'|'PHPDoc' (default: 'comment')
      */
@@ -309,13 +312,26 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
      * Enable the header comment fixer with a simple header text.
      *
      * @param string $header The header text (will be wrapped in comment block automatically)
-     * @param string $location Where to place the header (default: 'after_declare_strict')
+     * @param string|array<string> $location Where to place the header (default: 'after_declare_strict')
+     *                                       Can be a string or array. When using array, last matching position wins.
      */
-    public function enableHeaderComment(string $header, string $location = 'after_declare_strict'): static
+    public function enableHeaderComment(string $header, string|array $location = 'after_declare_strict'): static
     {
         return $this->setHeaderComment([
             'enabled' => true,
             'header' => $header,
+            'location' => $location,
+            'separate' => 'both',
+            'comment_type' => 'comment',
+        ]);
+    }
+
+    public function enableHeaderTemplateComment(string $headerTemplate, array $packagesPath = [], string|array $location = 'after_declare_strict'): static
+    {
+        return $this->setHeaderComment([
+            'enabled' => true,
+            'header_template' => $headerTemplate,
+            'packages_path' => $packagesPath,
             'location' => $location,
             'separate' => 'both',
             'comment_type' => 'comment',

--- a/src/Fixer/HeaderCommentFixer.php
+++ b/src/Fixer/HeaderCommentFixer.php
@@ -31,11 +31,19 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
     private string $headerComment = '';
+
     private bool $enabled = true;
+
     private string $location = 'after_declare_strict';
+
     private string $separate = 'both';
+
+    private string $commentType = 'comment';
+
     private array $packagesPath = [];
+
     private string $headerTemplate = '';
+
     private array $composerCache = [];
 
     public function getDefinition(): FixerDefinitionInterface
@@ -55,8 +63,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
 
     public function getPriority(): int
     {
-        // Run after declare_strict_types fixer
-        return -10;
+        return 20;
     }
 
     public function isCandidate(Tokens $tokens): bool
@@ -68,6 +75,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
     {
         if (!$this->enabled) {
             $this->removeHeader($tokens);
+
             return;
         }
 
@@ -76,6 +84,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
 
         if (empty($resolvedHeader)) {
             $this->removeHeader($tokens);
+
             return;
         }
 
@@ -88,6 +97,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         $this->headerComment = $configuration['header'] ?? '';
         $this->location = $configuration['location'] ?? 'after_declare_strict';
         $this->separate = $configuration['separate'] ?? 'both';
+        $this->commentType = $configuration['comment_type'] ?? 'comment';
         $this->packagesPath = $configuration['packages_path'] ?? [];
         $this->headerTemplate = $configuration['header_template'] ?? '';
         $this->composerCache = [];
@@ -95,38 +105,39 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
 
     public function getConfigurationDefinition(): FixerConfigurationResolverInterface
     {
-        return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('enabled', 'Whether the fixer is enabled.'))
-                ->setAllowedTypes(['bool'])
-                ->setDefault(true)
-                ->getOption(),
-            (new FixerOptionBuilder('header', 'The header comment text.'))
-                ->setAllowedTypes(['string'])
-                ->setDefault('')
-                ->getOption(),
-            (new FixerOptionBuilder('location', 'The location of the header comment.'))
-                ->setAllowedValues(['after_open', 'after_declare_strict'])
-                ->setDefault('after_declare_strict')
-                ->getOption(),
-            (new FixerOptionBuilder('separate', 'Whether to separate the header with newlines.'))
-                ->setAllowedValues(['both', 'top', 'bottom', 'none'])
-                ->setDefault('both')
-                ->getOption(),
-            (new FixerOptionBuilder('comment_type', 'The comment type to use for the header.'))
-                ->setAllowedValues(['comment', 'PHPDoc'])
-                ->setDefault('comment')
-                ->getOption(),
-            (new FixerOptionBuilder('packages_path', 'Array of paths to package directories for monorepo support.'))
-                ->setAllowedTypes(['array'])
-                ->setDefault([])
-                ->getOption(),
-            (new FixerOptionBuilder('header_template', 'Template string for package headers. Use {package_name} placeholder.'))
-                ->setAllowedTypes(['string'])
-                ->setDefault('')
-                ->getOption(),
-        ]);
+        return new FixerConfigurationResolver(
+            [
+                (new FixerOptionBuilder('enabled', 'Whether the fixer is enabled.'))
+                    ->setAllowedTypes([ 'bool' ])
+                    ->setDefault(true)
+                    ->getOption(),
+                (new FixerOptionBuilder('header', 'The header comment text.'))
+                    ->setAllowedTypes([ 'string' ])
+                    ->setDefault('')
+                    ->getOption(),
+                (new FixerOptionBuilder('location', 'The location of the header comment.'))
+                    ->setAllowedValues([ 'after_open', 'after_declare_strict' ])
+                    ->setDefault('after_declare_strict')
+                    ->getOption(),
+                (new FixerOptionBuilder('separate', 'Whether to separate the header with newlines.'))
+                    ->setAllowedValues([ 'both', 'top', 'bottom', 'none' ])
+                    ->setDefault('both')
+                    ->getOption(),
+                (new FixerOptionBuilder('comment_type', 'The comment type to use for the header.'))
+                    ->setAllowedValues([ 'comment', 'PHPDoc' ])
+                    ->setDefault('comment')
+                    ->getOption(),
+                (new FixerOptionBuilder('packages_path', 'Array of paths to package directories for monorepo support.'))
+                    ->setAllowedTypes([ 'array' ])
+                    ->setDefault([])
+                    ->getOption(),
+                (new FixerOptionBuilder('header_template', 'Template string for package headers. Use {package_name} placeholder.'))
+                    ->setAllowedTypes([ 'string' ])
+                    ->setDefault('')
+                    ->getOption(),
+            ]
+        );
     }
-
 
     private function insertHeader(Tokens $tokens, string $headerText): void
     {
@@ -142,26 +153,12 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
             return;
         }
 
-        // Prepare tokens to insert
-        $tokensToInsert = [];
+        // Add the header comment with correct token type
+        $commentTokenType = $this->commentType === 'PHPDoc' ? T_DOC_COMMENT : T_COMMENT;
+        $tokens->insertAt($insertionIndex, new Token([ $commentTokenType, $headerComment ]));
 
-        // Add blank line before if needed
-        if ($this->separate === 'both' || $this->separate === 'top') {
-            $tokensToInsert[] = new Token([T_WHITESPACE, "\n"]);
-        }
-
-        // Add the header comment
-        $tokensToInsert[] = new Token([T_COMMENT, $headerComment]);
-
-        // Add blank line after if needed
-        if ($this->separate === 'both' || $this->separate === 'bottom') {
-            $tokensToInsert[] = new Token([T_WHITESPACE, "\n\n"]);
-        } else {
-            $tokensToInsert[] = new Token([T_WHITESPACE, "\n"]);
-        }
-
-        // Insert the tokens
-        $tokens->insertAt($insertionIndex, $tokensToInsert);
+        // Fix whitespace around the header to ensure proper spacing
+        $this->fixWhiteSpaceAroundHeader($tokens, $insertionIndex);
     }
 
     private function removeHeader(Tokens $tokens): void
@@ -172,55 +169,77 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
             return;
         }
 
-        // Find the end of the header comment
-        $headerEnd = $headerStart;
         $token = $tokens[$headerStart];
 
         if ($token->isGivenKind(T_COMMENT) || $token->isGivenKind(T_DOC_COMMENT)) {
+            // Remove whitespace before the header comment if present
+            $prevIndex = $headerStart - 1;
+            if ($prevIndex >= 0 && $tokens[$prevIndex]->isWhitespace()) {
+                $tokens->clearAt($prevIndex);
+            }
+
             // Remove the comment token
             $tokens->clearAt($headerStart);
 
-            // Also remove trailing whitespace
-            $nextIndex = $tokens->getNextNonWhitespace($headerStart);
-            if ($nextIndex !== null && $tokens[$nextIndex]->isWhitespace()) {
+            // Remove whitespace after the header comment
+            $nextIndex = $headerStart + 1;
+            while ($nextIndex < count($tokens) && $tokens[$nextIndex]->isWhitespace()) {
                 $tokens->clearAt($nextIndex);
+                $nextIndex++;
             }
         }
     }
 
     private function findInsertionPoint(Tokens $tokens): ?int
     {
-        $openTagIndex = $tokens->getNextTokenOfKind(0, [[T_OPEN_TAG]]);
-
-        if ($openTagIndex === null) {
+        // Start from -1 since getNextTokenOfKind searches from index+1
+        $openTagIndex = 0;
+        if (!$tokens[0]->isGivenKind(T_OPEN_TAG)) {
             return null;
         }
 
         if ($this->location === 'after_open') {
-            return $openTagIndex + 1;
+            // Insert right after the opening tag
+            $nextIndex = $openTagIndex + 1;
+            // Skip any existing whitespace
+            while ($nextIndex < count($tokens) && $tokens[$nextIndex]->isWhitespace()) {
+                $nextIndex++;
+            }
+
+            return $nextIndex;
         }
 
         // Find declare(strict_types=1);
-        $declareIndex = $tokens->getNextTokenOfKind($openTagIndex, [[T_DECLARE]]);
+        $declareIndex = $tokens->getNextTokenOfKind($openTagIndex, [ [ T_DECLARE ] ]);
 
         if ($declareIndex !== null) {
             // Find the semicolon after declare
-            $semicolonIndex = $tokens->getNextTokenOfKind($declareIndex, [';']);
+            $semicolonIndex = $tokens->getNextTokenOfKind($declareIndex, [ ';' ]);
 
             if ($semicolonIndex !== null) {
-                return $tokens->getNextMeaningfulToken($semicolonIndex);
+                // Skip whitespace after semicolon to find insertion point
+                $nextIndex = $semicolonIndex + 1;
+                while ($nextIndex < count($tokens) && $tokens[$nextIndex]->isWhitespace()) {
+                    $nextIndex++;
+                }
+
+                return $nextIndex;
             }
         }
 
-        // Fallback to after open tag
-        return $tokens->getNextMeaningfulToken($openTagIndex);
+        // Fallback to after open tag if no declare found
+        $nextIndex = $openTagIndex + 1;
+        while ($nextIndex < count($tokens) && $tokens[$nextIndex]->isWhitespace()) {
+            $nextIndex++;
+        }
+
+        return $nextIndex;
     }
 
     private function findExistingHeaderStart(Tokens $tokens): ?int
     {
-        $openTagIndex = $tokens->getNextTokenOfKind(0, [[T_OPEN_TAG]]);
-
-        if ($openTagIndex === null) {
+        $openTagIndex = 0;
+        if (!$tokens[0]->isGivenKind(T_OPEN_TAG)) {
             return null;
         }
 
@@ -228,9 +247,9 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         $searchStart = $openTagIndex + 1;
 
         // Skip past declare if present
-        $declareIndex = $tokens->getNextTokenOfKind($openTagIndex, [[T_DECLARE]]);
+        $declareIndex = $tokens->getNextTokenOfKind($openTagIndex, [ [ T_DECLARE ] ]);
         if ($declareIndex !== null) {
-            $semicolonIndex = $tokens->getNextTokenOfKind($declareIndex, [';']);
+            $semicolonIndex = $tokens->getNextTokenOfKind($declareIndex, [ ';' ]);
             if ($semicolonIndex !== null) {
                 $searchStart = $semicolonIndex + 1;
             }
@@ -244,7 +263,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
                 continue;
             }
 
-            if ($token->isGivenKind([T_COMMENT, T_DOC_COMMENT])) {
+            if ($token->isGivenKind([ T_COMMENT, T_DOC_COMMENT ])) {
                 // Check if this looks like a header comment (multi-line block comment)
                 $content = $token->getContent();
                 if (str_starts_with($content, '/*') && !str_starts_with($content, '/**')) {
@@ -253,7 +272,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
             }
 
             // Stop at the first non-whitespace, non-comment token
-            if (!$token->isGivenKind([T_COMMENT, T_DOC_COMMENT])) {
+            if (!$token->isGivenKind([ T_COMMENT, T_DOC_COMMENT ])) {
                 break;
             }
         }
@@ -269,7 +288,10 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
             return '';
         }
 
-        $comment = "/*\n";
+        // Use /** */ for PHPDoc style, /* */ for regular comment
+        $commentStart = $this->commentType === 'PHPDoc' ? "/**\n" : "/*\n";
+
+        $comment = $commentStart;
         foreach ($lines as $line) {
             $comment .= ' * ' . $line . "\n";
         }
@@ -302,8 +324,11 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
             return $this->headerComment;
         }
 
+        $this->headerTemplate = str_replace('{package_name}', $packageName, $this->headerTemplate);
+        $this->headerTemplate = str_replace('{year}', (new \DateTime())->format('Y'), $this->headerTemplate);
+
         // Replace placeholder in template
-        return str_replace('{package_name}', $packageName, $this->headerTemplate);
+        return $this->headerTemplate;
     }
 
     /**
@@ -356,18 +381,21 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
 
         if (!file_exists($composerJsonPath)) {
             $this->composerCache[$packageDir] = null;
+
             return null;
         }
 
         $composerJson = file_get_contents($composerJsonPath);
         if ($composerJson === false) {
             $this->composerCache[$packageDir] = null;
+
             return null;
         }
 
         $composerData = json_decode($composerJson, true);
         if (!is_array($composerData) || !isset($composerData['name'])) {
             $this->composerCache[$packageDir] = null;
+
             return null;
         }
 
@@ -375,6 +403,91 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         $this->composerCache[$packageDir] = $packageName;
 
         return $packageName;
+    }
+
+    /**
+     * Count line breaks in a specific direction from the given index.
+     */
+    private function getLineBreakCount(Tokens $tokens, int $index, int $direction): int
+    {
+        $whitespace = '';
+        $adjacentIndex = $index + $direction;
+
+        while ($adjacentIndex >= 0 && $adjacentIndex < count($tokens)) {
+            $token = $tokens[$adjacentIndex];
+
+            if ($token->isWhitespace()) {
+                $whitespace .= $token->getContent();
+                $adjacentIndex += $direction;
+            } else {
+                break;
+            }
+        }
+
+        return substr_count($whitespace, "\n");
+    }
+
+    /**
+     * Fix whitespace around the header comment to ensure proper spacing.
+     */
+    private function fixWhiteSpaceAroundHeader(Tokens $tokens, int $headerIndex): void
+    {
+        $lineEnding = "\n";
+
+        // Fix lines after header comment
+        if (
+            ($this->separate === 'both' || $this->separate === 'bottom')
+            && null !== $tokens->getNextMeaningfulToken($headerIndex)
+        ) {
+            $expectedLineCount = 2;
+        } else {
+            $expectedLineCount = 1;
+        }
+
+        if ($headerIndex === count($tokens) - 1) {
+            $tokens->insertAt($headerIndex + 1, new Token([ T_WHITESPACE, str_repeat($lineEnding, $expectedLineCount) ]));
+        } else {
+            $lineBreakCount = $this->getLineBreakCount($tokens, $headerIndex, 1);
+
+            if ($lineBreakCount < $expectedLineCount) {
+                $missing = str_repeat($lineEnding, $expectedLineCount - $lineBreakCount);
+
+                if ($tokens[$headerIndex + 1]->isWhitespace()) {
+                    $tokens[$headerIndex + 1] = new Token([ T_WHITESPACE, $missing . $tokens[$headerIndex + 1]->getContent() ]);
+                } else {
+                    $tokens->insertAt($headerIndex + 1, new Token([ T_WHITESPACE, $missing ]));
+                }
+            } elseif ($lineBreakCount > $expectedLineCount && $tokens[$headerIndex + 1]->isWhitespace()) {
+                $newLinesToRemove = $lineBreakCount - $expectedLineCount;
+                $content = $tokens[$headerIndex + 1]->getContent();
+                // Remove extra newlines from the beginning
+                $tokens[$headerIndex + 1] = new Token(
+                    [
+                        T_WHITESPACE,
+                        preg_replace("/^(?:\\r\\n|\\n|\\r){{$newLinesToRemove}}/", '', $content),
+                    ]
+                );
+            }
+        }
+
+        // Fix lines before header comment
+        $expectedLineCount = ($this->separate === 'both' || $this->separate === 'top') ? 2 : 1;
+        $prev = $tokens->getPrevNonWhitespace($headerIndex);
+
+        if ($prev !== null) {
+            $regex = '/\h$/';
+
+            if ($tokens[$prev]->isGivenKind(T_OPEN_TAG) && preg_match($regex, $tokens[$prev]->getContent())) {
+                $tokens[$prev] = new Token([ T_OPEN_TAG, preg_replace($regex, $lineEnding, $tokens[$prev]->getContent()) ]);
+            }
+        }
+
+        $lineBreakCount = $this->getLineBreakCount($tokens, $headerIndex, -1);
+
+        if ($lineBreakCount < $expectedLineCount) {
+            // Insert missing line breaks before the header
+            $tokens->insertAt($headerIndex, new Token([ T_WHITESPACE, str_repeat($lineEnding, $expectedLineCount - $lineBreakCount) ]));
+        }
     }
 }
 

--- a/src/Fixer/HeaderCommentFixer.php
+++ b/src/Fixer/HeaderCommentFixer.php
@@ -135,7 +135,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
                     ->setAllowedTypes([ 'string' ])
                     ->setDefault('')
                     ->getOption(),
-            ]
+            ],
         );
     }
 
@@ -174,6 +174,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         if ($token->isGivenKind(T_COMMENT) || $token->isGivenKind(T_DOC_COMMENT)) {
             // Remove whitespace before the header comment if present
             $prevIndex = $headerStart - 1;
+
             if ($prevIndex >= 0 && $tokens[$prevIndex]->isWhitespace()) {
                 $tokens->clearAt($prevIndex);
             }
@@ -183,6 +184,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
 
             // Remove whitespace after the header comment
             $nextIndex = $headerStart + 1;
+
             while ($nextIndex < count($tokens) && $tokens[$nextIndex]->isWhitespace()) {
                 $tokens->clearAt($nextIndex);
                 $nextIndex++;
@@ -190,10 +192,11 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         }
     }
 
-    private function findInsertionPoint(Tokens $tokens): ?int
+    private function findInsertionPoint(Tokens $tokens): int|null
     {
         // Start from -1 since getNextTokenOfKind searches from index+1
         $openTagIndex = 0;
+
         if (!$tokens[0]->isGivenKind(T_OPEN_TAG)) {
             return null;
         }
@@ -201,6 +204,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         if ($this->location === 'after_open') {
             // Insert right after the opening tag
             $nextIndex = $openTagIndex + 1;
+
             // Skip any existing whitespace
             while ($nextIndex < count($tokens) && $tokens[$nextIndex]->isWhitespace()) {
                 $nextIndex++;
@@ -219,6 +223,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
             if ($semicolonIndex !== null) {
                 // Skip whitespace after semicolon to find insertion point
                 $nextIndex = $semicolonIndex + 1;
+
                 while ($nextIndex < count($tokens) && $tokens[$nextIndex]->isWhitespace()) {
                     $nextIndex++;
                 }
@@ -229,6 +234,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
 
         // Fallback to after open tag if no declare found
         $nextIndex = $openTagIndex + 1;
+
         while ($nextIndex < count($tokens) && $tokens[$nextIndex]->isWhitespace()) {
             $nextIndex++;
         }
@@ -236,9 +242,10 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         return $nextIndex;
     }
 
-    private function findExistingHeaderStart(Tokens $tokens): ?int
+    private function findExistingHeaderStart(Tokens $tokens): int|null
     {
         $openTagIndex = 0;
+
         if (!$tokens[0]->isGivenKind(T_OPEN_TAG)) {
             return null;
         }
@@ -248,8 +255,10 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
 
         // Skip past declare if present
         $declareIndex = $tokens->getNextTokenOfKind($openTagIndex, [ [ T_DECLARE ] ]);
+
         if ($declareIndex !== null) {
             $semicolonIndex = $tokens->getNextTokenOfKind($declareIndex, [ ';' ]);
+
             if ($semicolonIndex !== null) {
                 $searchStart = $semicolonIndex + 1;
             }
@@ -266,6 +275,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
             if ($token->isGivenKind([ T_COMMENT, T_DOC_COMMENT ])) {
                 // Check if this looks like a header comment (multi-line block comment)
                 $content = $token->getContent();
+
                 if (str_starts_with($content, '/*') && !str_starts_with($content, '/**')) {
                     return $i;
                 }
@@ -292,6 +302,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         $commentStart = $this->commentType === 'PHPDoc' ? "/**\n" : "/*\n";
 
         $comment = $commentStart;
+
         foreach ($lines as $line) {
             $comment .= ' * ' . $line . "\n";
         }
@@ -313,6 +324,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         }
 
         $filePath = $file->getRealPath();
+
         if ($filePath === false) {
             return $this->headerComment;
         }
@@ -334,7 +346,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
     /**
      * Find the package name from composer.json for a given file path.
      */
-    private function findPackageNameForFile(string $filePath): ?string
+    private function findPackageNameForFile(string $filePath): string|null
     {
         foreach ($this->packagesPath as $packagesRoot) {
             // Normalize paths
@@ -370,7 +382,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
      * Read the package name from composer.json in the given directory.
      * Results are cached to avoid repeated file reads.
      */
-    private function getPackageNameFromComposer(string $packageDir): ?string
+    private function getPackageNameFromComposer(string $packageDir): string|null
     {
         // Check cache first
         if (isset($this->composerCache[$packageDir])) {
@@ -386,6 +398,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         }
 
         $composerJson = file_get_contents($composerJsonPath);
+
         if ($composerJson === false) {
             $this->composerCache[$packageDir] = null;
 
@@ -393,6 +406,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         }
 
         $composerData = json_decode($composerJson, true);
+
         if (!is_array($composerData) || !isset($composerData['name'])) {
             $this->composerCache[$packageDir] = null;
 
@@ -437,7 +451,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         // Fix lines after header comment
         if (
             ($this->separate === 'both' || $this->separate === 'bottom')
-            && null !== $tokens->getNextMeaningfulToken($headerIndex)
+            && $tokens->getNextMeaningfulToken($headerIndex) !== null
         ) {
             $expectedLineCount = 2;
         } else {
@@ -465,7 +479,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
                     [
                         T_WHITESPACE,
                         preg_replace("/^(?:\\r\\n|\\n|\\r){{$newLinesToRemove}}/", '', $content),
-                    ]
+                    ],
                 );
             }
         }
@@ -490,4 +504,3 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         }
     }
 }
-

--- a/src/Fixer/HeaderCommentFixer.php
+++ b/src/Fixer/HeaderCommentFixer.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the FULLHAUS PHP-CS-Fixer configuration.
+ *
+ * (c) 2026 FULLHAUS GmbH
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace FULLHAUS\CodingStandards\Fixer;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * Custom fixer for adding/managing header comments in mono repo projects.
+ *
+ * This fixer allows configuring different headers per project within a mono repo structure.
+ */
+final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixerInterface
+{
+    private string $headerComment = '';
+    private bool $enabled = true;
+    private string $location = 'after_declare_strict';
+    private string $separate = 'both';
+    private array $packagesPath = [];
+    private string $headerTemplate = '';
+    private array $composerCache = [];
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Add, replace or remove header comment for mono repo projects.',
+            [
+                // You can add code samples here if needed
+            ],
+        );
+    }
+
+    public function getName(): string
+    {
+        return 'FULLHAUS/header_comment';
+    }
+
+    public function getPriority(): int
+    {
+        // Run after declare_strict_types fixer
+        return -10;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $this->enabled && $tokens->isTokenKindFound(T_OPEN_TAG);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        if (!$this->enabled) {
+            $this->removeHeader($tokens);
+            return;
+        }
+
+        // Resolve the header for this specific file
+        $resolvedHeader = $this->resolveHeaderForFile($file);
+
+        if (empty($resolvedHeader)) {
+            $this->removeHeader($tokens);
+            return;
+        }
+
+        $this->insertHeader($tokens, $resolvedHeader);
+    }
+
+    public function configure(array $configuration): void
+    {
+        $this->enabled = $configuration['enabled'] ?? true;
+        $this->headerComment = $configuration['header'] ?? '';
+        $this->location = $configuration['location'] ?? 'after_declare_strict';
+        $this->separate = $configuration['separate'] ?? 'both';
+        $this->packagesPath = $configuration['packages_path'] ?? [];
+        $this->headerTemplate = $configuration['header_template'] ?? '';
+        $this->composerCache = [];
+    }
+
+    public function getConfigurationDefinition(): FixerConfigurationResolverInterface
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('enabled', 'Whether the fixer is enabled.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(true)
+                ->getOption(),
+            (new FixerOptionBuilder('header', 'The header comment text.'))
+                ->setAllowedTypes(['string'])
+                ->setDefault('')
+                ->getOption(),
+            (new FixerOptionBuilder('location', 'The location of the header comment.'))
+                ->setAllowedValues(['after_open', 'after_declare_strict'])
+                ->setDefault('after_declare_strict')
+                ->getOption(),
+            (new FixerOptionBuilder('separate', 'Whether to separate the header with newlines.'))
+                ->setAllowedValues(['both', 'top', 'bottom', 'none'])
+                ->setDefault('both')
+                ->getOption(),
+            (new FixerOptionBuilder('comment_type', 'The comment type to use for the header.'))
+                ->setAllowedValues(['comment', 'PHPDoc'])
+                ->setDefault('comment')
+                ->getOption(),
+            (new FixerOptionBuilder('packages_path', 'Array of paths to package directories for monorepo support.'))
+                ->setAllowedTypes(['array'])
+                ->setDefault([])
+                ->getOption(),
+            (new FixerOptionBuilder('header_template', 'Template string for package headers. Use {package_name} placeholder.'))
+                ->setAllowedTypes(['string'])
+                ->setDefault('')
+                ->getOption(),
+        ]);
+    }
+
+
+    private function insertHeader(Tokens $tokens, string $headerText): void
+    {
+        // Remove existing header first
+        $this->removeHeader($tokens);
+
+        $headerComment = $this->buildHeaderComment($headerText);
+
+        // Find insertion point
+        $insertionIndex = $this->findInsertionPoint($tokens);
+
+        if ($insertionIndex === null) {
+            return;
+        }
+
+        // Prepare tokens to insert
+        $tokensToInsert = [];
+
+        // Add blank line before if needed
+        if ($this->separate === 'both' || $this->separate === 'top') {
+            $tokensToInsert[] = new Token([T_WHITESPACE, "\n"]);
+        }
+
+        // Add the header comment
+        $tokensToInsert[] = new Token([T_COMMENT, $headerComment]);
+
+        // Add blank line after if needed
+        if ($this->separate === 'both' || $this->separate === 'bottom') {
+            $tokensToInsert[] = new Token([T_WHITESPACE, "\n\n"]);
+        } else {
+            $tokensToInsert[] = new Token([T_WHITESPACE, "\n"]);
+        }
+
+        // Insert the tokens
+        $tokens->insertAt($insertionIndex, $tokensToInsert);
+    }
+
+    private function removeHeader(Tokens $tokens): void
+    {
+        $headerStart = $this->findExistingHeaderStart($tokens);
+
+        if ($headerStart === null) {
+            return;
+        }
+
+        // Find the end of the header comment
+        $headerEnd = $headerStart;
+        $token = $tokens[$headerStart];
+
+        if ($token->isGivenKind(T_COMMENT) || $token->isGivenKind(T_DOC_COMMENT)) {
+            // Remove the comment token
+            $tokens->clearAt($headerStart);
+
+            // Also remove trailing whitespace
+            $nextIndex = $tokens->getNextNonWhitespace($headerStart);
+            if ($nextIndex !== null && $tokens[$nextIndex]->isWhitespace()) {
+                $tokens->clearAt($nextIndex);
+            }
+        }
+    }
+
+    private function findInsertionPoint(Tokens $tokens): ?int
+    {
+        $openTagIndex = $tokens->getNextTokenOfKind(0, [[T_OPEN_TAG]]);
+
+        if ($openTagIndex === null) {
+            return null;
+        }
+
+        if ($this->location === 'after_open') {
+            return $openTagIndex + 1;
+        }
+
+        // Find declare(strict_types=1);
+        $declareIndex = $tokens->getNextTokenOfKind($openTagIndex, [[T_DECLARE]]);
+
+        if ($declareIndex !== null) {
+            // Find the semicolon after declare
+            $semicolonIndex = $tokens->getNextTokenOfKind($declareIndex, [';']);
+
+            if ($semicolonIndex !== null) {
+                return $tokens->getNextMeaningfulToken($semicolonIndex);
+            }
+        }
+
+        // Fallback to after open tag
+        return $tokens->getNextMeaningfulToken($openTagIndex);
+    }
+
+    private function findExistingHeaderStart(Tokens $tokens): ?int
+    {
+        $openTagIndex = $tokens->getNextTokenOfKind(0, [[T_OPEN_TAG]]);
+
+        if ($openTagIndex === null) {
+            return null;
+        }
+
+        // Look for comments after the open tag and potentially after declare
+        $searchStart = $openTagIndex + 1;
+
+        // Skip past declare if present
+        $declareIndex = $tokens->getNextTokenOfKind($openTagIndex, [[T_DECLARE]]);
+        if ($declareIndex !== null) {
+            $semicolonIndex = $tokens->getNextTokenOfKind($declareIndex, [';']);
+            if ($semicolonIndex !== null) {
+                $searchStart = $semicolonIndex + 1;
+            }
+        }
+
+        // Look for the first comment after our search start point
+        for ($i = $searchStart; $i < count($tokens); $i++) {
+            $token = $tokens[$i];
+
+            if ($token->isWhitespace()) {
+                continue;
+            }
+
+            if ($token->isGivenKind([T_COMMENT, T_DOC_COMMENT])) {
+                // Check if this looks like a header comment (multi-line block comment)
+                $content = $token->getContent();
+                if (str_starts_with($content, '/*') && !str_starts_with($content, '/**')) {
+                    return $i;
+                }
+            }
+
+            // Stop at the first non-whitespace, non-comment token
+            if (!$token->isGivenKind([T_COMMENT, T_DOC_COMMENT])) {
+                break;
+            }
+        }
+
+        return null;
+    }
+
+    private function buildHeaderComment(string $headerText): string
+    {
+        $lines = explode("\n", trim($headerText));
+
+        if (count($lines) === 0 || (count($lines) === 1 && empty($lines[0]))) {
+            return '';
+        }
+
+        $comment = "/*\n";
+        foreach ($lines as $line) {
+            $comment .= ' * ' . $line . "\n";
+        }
+        $comment .= ' */';
+
+        return $comment;
+    }
+
+    /**
+     * Resolve the header for a specific file.
+     * If packages_path and header_template are configured, finds the package
+     * and generates a header based on the composer.json name.
+     */
+    private function resolveHeaderForFile(\SplFileInfo $file): string
+    {
+        // If no packages path configured, use default header
+        if (empty($this->packagesPath) || empty($this->headerTemplate)) {
+            return $this->headerComment;
+        }
+
+        $filePath = $file->getRealPath();
+        if ($filePath === false) {
+            return $this->headerComment;
+        }
+
+        // Find which package this file belongs to
+        $packageName = $this->findPackageNameForFile($filePath);
+
+        if ($packageName === null) {
+            return $this->headerComment;
+        }
+
+        // Replace placeholder in template
+        return str_replace('{package_name}', $packageName, $this->headerTemplate);
+    }
+
+    /**
+     * Find the package name from composer.json for a given file path.
+     */
+    private function findPackageNameForFile(string $filePath): ?string
+    {
+        foreach ($this->packagesPath as $packagesRoot) {
+            // Normalize paths
+            $packagesRoot = rtrim($packagesRoot, '/');
+
+            // Check if file is within this packages root
+            if (!str_starts_with($filePath, $packagesRoot)) {
+                continue;
+            }
+
+            // Find the package directory (first directory level under packages root)
+            $relativePath = substr($filePath, strlen($packagesRoot) + 1);
+            $pathParts = explode('/', $relativePath);
+
+            if (empty($pathParts[0])) {
+                continue;
+            }
+
+            $packageDir = $packagesRoot . '/' . $pathParts[0];
+
+            // Get package name from composer.json
+            $packageName = $this->getPackageNameFromComposer($packageDir);
+
+            if ($packageName !== null) {
+                return $packageName;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Read the package name from composer.json in the given directory.
+     * Results are cached to avoid repeated file reads.
+     */
+    private function getPackageNameFromComposer(string $packageDir): ?string
+    {
+        // Check cache first
+        if (isset($this->composerCache[$packageDir])) {
+            return $this->composerCache[$packageDir];
+        }
+
+        $composerJsonPath = $packageDir . '/composer.json';
+
+        if (!file_exists($composerJsonPath)) {
+            $this->composerCache[$packageDir] = null;
+            return null;
+        }
+
+        $composerJson = file_get_contents($composerJsonPath);
+        if ($composerJson === false) {
+            $this->composerCache[$packageDir] = null;
+            return null;
+        }
+
+        $composerData = json_decode($composerJson, true);
+        if (!is_array($composerData) || !isset($composerData['name'])) {
+            $this->composerCache[$packageDir] = null;
+            return null;
+        }
+
+        $packageName = $composerData['name'];
+        $this->composerCache[$packageDir] = $packageName;
+
+        return $packageName;
+    }
+}
+

--- a/src/Fixer/HeaderCommentFixer.php
+++ b/src/Fixer/HeaderCommentFixer.php
@@ -256,7 +256,7 @@ final class HeaderCommentFixer extends AbstractFixer implements ConfigurableFixe
         }
 
         // Look for the first comment after our search start point
-        for ($i = $searchStart; $i < count($tokens); $i++) {
+        for ($i = $searchStart, $iMax = count($tokens); $i < $iMax; $i++) {
             $token = $tokens[$i];
 
             if ($token->isWhitespace()) {


### PR DESCRIPTION
This pull request introduces a new custom header comment fixer for mono repo projects and updates the documentation and configuration to support it. The most significant changes are the addition of new configuration methods for header comments in `CsFixerConfig`, registration of the custom fixer, and comprehensive documentation updates.

**Header comment fixer integration:**

* Added registration of the new `HeaderCommentFixer` custom fixer in the `CsFixerConfig::create()` method, enabling header comment management as part of the code style rules. [[1]](diffhunk://#diff-ac56343a3aec783bc91012a8ad72be0b6d3e1463b6b52be062ed1bff2ef7aa01R17) [[2]](diffhunk://#diff-ac56343a3aec783bc91012a8ad72be0b6d3e1463b6b52be062ed1bff2ef7aa01L245-R249)
* Introduced new methods in `CsFixerConfig` for configuring header comments:
  - `setHeaderComment()` for advanced configuration.
  - `enableHeaderComment()` for simple header text.
  - `enableHeaderTemplateComment()` for template-based headers in monorepos.
  - `disableHeaderComment()` to turn off the fixer.

**Documentation updates:**

* Expanded the `README.md` to document the new header comment fixer, including usage examples, configuration options, and key features like automatic package detection and per-package headers in mono repos.
* Improved code snippets in the installation steps for clarity and accuracy.