### PR TITLE
feat: add case sensitivity to ordered types

### DIFF
--- a/src/CsFixerConfig.php
+++ b/src/CsFixerConfig.php
@@ -161,6 +161,7 @@ class CsFixerConfig extends Config implements CsFixerConfigInterface
             ],
         ],
         'ordered_types' => [
+            'case_sensitive' => true,
             'null_adjustment' => 'always_last',
             'sort_algorithm' => 'alpha',
         ],

--- a/tests/StyleValidationTest.php
+++ b/tests/StyleValidationTest.php
@@ -182,20 +182,20 @@ function test(string|null $value): int|null
     }
 
     /**
-     * Test nullable type with union syntax
+     * Test type order with union syntax
      */
     public function testNullableOrder(): void
     {
         $input = '<?php
 
-function test(null|string $value): null|int
+function test(null|\CallbackFilterIterator|string $value): null|int
 {
     return null;
 }
 ';
         $expected = '<?php
 
-function test(string|null $value): int|null
+function test(\CallbackFilterIterator|string|null $value): int|null
 {
     return null;
 }

--- a/tests/StyleValidationTest.php
+++ b/tests/StyleValidationTest.php
@@ -184,7 +184,7 @@ function test(string|null $value): int|null
     /**
      * Test type order with union syntax
      */
-    public function testNullableOrder(): void
+    public function testTypeOrder(): void
     {
         $input = '<?php
 


### PR DESCRIPTION
This pull request makes a small but important adjustment to type ordering in both the code style configuration and its corresponding test. The main change enforces case-sensitive sorting for types and updates the test to reflect this behavior.

**Code Style Configuration:**

* Enabled case-sensitive sorting for the `ordered_types` rule in the CS Fixer configuration by adding `'case_sensitive' => true`.

**Tests:**

* Updated the `testNullableOrder` test to use a class type (`\CallbackFilterIterator`) and to expect types to be ordered case-sensitively, matching the new configuration.